### PR TITLE
chore(lib): avoid naming collision in consumer app 

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 		"access": "public"
 	},
 	"peerDependencies": {
-		"svelte": "^4.0.0"
+		"svelte": "^4.0.0",
+		"thirdweb": "^5.73.0"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	},
 	"peerDependencies": {
 		"svelte": "^4.0.0",
-		"thirdweb": "^5.73.0"
+		"thirdweb": "^5.0.0"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holdex/thirdweb-svelte",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",

--- a/src/lib/components/auto-connect.svelte
+++ b/src/lib/components/auto-connect.svelte
@@ -34,6 +34,7 @@
 				console.error(err);
 			} finally {
 				context.isAutoConnecting.set(false);
+				context.isInitialized.set(true);
 			}
 		})();
 	}

--- a/src/lib/components/auto-connect.svelte
+++ b/src/lib/components/auto-connect.svelte
@@ -22,6 +22,8 @@
 			try {
 				const activeWallet =
 					walletId && (availableWallets.find((w) => w.id === walletId) || createWallet(walletId));
+				if (!activeWallet) return;
+
 				await activeWallet.autoConnect({
 					client: context.client,
 					chain: preferredChain

--- a/src/lib/components/thirdweb-svelte-provider/context.ts
+++ b/src/lib/components/thirdweb-svelte-provider/context.ts
@@ -6,6 +6,7 @@ import type { Account, Wallet } from 'thirdweb/wallets';
 type ThirdwebSvelteContext = {
 	client: ThirdwebClient;
 	isAutoConnecting: Writable<boolean>;
+	isInitialized: Writable<boolean>;
 	wallet: Writable<Wallet | null>;
 	account: Writable<Account | null>;
 	connect: (wallet: Wallet) => void;

--- a/src/lib/components/thirdweb-svelte-provider/context.ts
+++ b/src/lib/components/thirdweb-svelte-provider/context.ts
@@ -11,9 +11,9 @@ type ThirdwebSvelteContext = {
 	connect: (wallet: Wallet) => void;
 	disconnect: () => void;
 };
-const getThirdwebSvelteContext = () => getContext<ThirdwebSvelteContext>('providerContext');
+const getThirdwebSvelteContext = () => getContext<ThirdwebSvelteContext>('thirdweb-svelte:context');
 const setThirdwebSvelteContext = (context: ThirdwebSvelteContext) => {
-	setContext('providerContext', context);
+	setContext('thirdweb-svelte:context', context);
 };
 
 export { getThirdwebSvelteContext, setThirdwebSvelteContext, type ThirdwebSvelteContext };

--- a/src/lib/components/thirdweb-svelte-provider/thirdweb-svelte-provider.svelte
+++ b/src/lib/components/thirdweb-svelte-provider/thirdweb-svelte-provider.svelte
@@ -12,6 +12,7 @@
 	const wallet = writable<Wallet | null>(null);
 	const account = writable<Account | null>(null);
 	const isAutoConnecting = writable(true);
+	const isInitialized = writable(false);
 
 	const disconnect = async () => {
 		lastActiveWalletIdStorage.remove();
@@ -29,7 +30,15 @@
 		lastActiveWalletIdStorage.set(newWallet.id);
 	};
 
-	setThirdwebSvelteContext({ wallet, client, account, disconnect, connect, isAutoConnecting });
+	setThirdwebSvelteContext({
+		wallet,
+		client,
+		account,
+		disconnect,
+		connect,
+		isAutoConnecting,
+		isInitialized
+	});
 
 	const queryClient = new QueryClient();
 </script>


### PR DESCRIPTION
Resolves #18 

# Other Changes
- Added thirdweb as peer dependencies to avoid type issues in consumer app
- Not call autoconnect if no account detected
- Add `isInitialized` field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the package version to `0.0.3` and added a new peer dependency for `thirdweb`.
	- Enhanced the auto-connection process by adding a check for the active wallet.
	- Introduced a new initialization state in the context management for the Thirdweb library.

- **Bug Fixes**
	- Ensured that the auto-connection process does not proceed without an active wallet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->