### PR TITLE
feat: switch to Sepolia/Mainnet using metamask (QR)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holdex/thirdweb-svelte",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",

--- a/src/lib/components/auto-connect.svelte
+++ b/src/lib/components/auto-connect.svelte
@@ -26,7 +26,7 @@
 
 				await activeWallet.autoConnect({
 					client: context.client,
-					chain: preferredChain
+					chain: preferredChain,
 				});
 				context.connect(activeWallet);
 			} catch (err) {

--- a/src/lib/components/connect-wallet-modal/steps/wallet-connect/injected-wallet-connect.svelte
+++ b/src/lib/components/connect-wallet-modal/steps/wallet-connect/injected-wallet-connect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getWalletInfoQuery } from '$/queries/wallets.js';
-	import type { Account, Wallet } from 'thirdweb/wallets';
+	import type { Wallet } from 'thirdweb/wallets';
 	import WalletLogoSpinner from './wallet-logo-spinner.svelte';
 	import type { Chain } from 'thirdweb';
 	import { wait } from '$/utils.js';
@@ -26,7 +26,7 @@
 			await wait(1000);
 			await wallet.connect({
 				client: context.client,
-				chain,
+				chain: chain || chains?.[0],
 				optionalChains: chains
 			});
 

--- a/src/lib/components/connect-wallet-modal/steps/wallet-connect/wallet-connect.svelte
+++ b/src/lib/components/connect-wallet-modal/steps/wallet-connect/wallet-connect.svelte
@@ -51,6 +51,7 @@
 			{onFinishConnect}
 			{wallet}
 			{chain}
+			{chains}
 		/>
 	{:else}
 		<WalletNotSupported />
@@ -70,9 +71,9 @@
 		<InjectedWalletConnect
 			onGetStartedClick={() => (screen = 'get-started')}
 			{chains}
+			{chain}
 			{onFinishConnect}
 			{wallet}
-			{chain}
 		/>
 	{:else if $walletInfoQuery.data.mobile.native && $walletInfoQuery.data.mobile.universal}
 		<WalletconnectConnect
@@ -96,10 +97,10 @@
 	{:else if wallet.id}
 		<InjectedWalletConnect
 			onGetStartedClick={() => (screen = 'get-started')}
-			{chains}
 			{onFinishConnect}
 			{wallet}
 			{chain}
+			{chains}
 		/>
 	{:else}
 		<WalletGetStarted {wallet} walletInfo={$walletInfoQuery.data} {setCustomBackClick} />

--- a/src/lib/components/connect-wallet-modal/steps/wallet-connect/walletconnect-connect.svelte
+++ b/src/lib/components/connect-wallet-modal/steps/wallet-connect/walletconnect-connect.svelte
@@ -32,7 +32,7 @@
 
 		try {
 			await wallet.connect({
-				chain,
+				chain: chain || chains?.[0],
 				client: context.client,
 				walletConnect: {
 					projectId: walletConnect?.projectId,

--- a/src/lib/components/connect-wallet-modal/steps/wallet-connect/walletconnect-connect.svelte
+++ b/src/lib/components/connect-wallet-modal/steps/wallet-connect/walletconnect-connect.svelte
@@ -14,6 +14,10 @@
 	import Copy from 'lucide-svelte/icons/copy';
 	import Check from 'lucide-svelte/icons/check';
 
+	// The chains that metamask don't allow custom RPC connections, making call of wallet_addEthereumChain which will be called by thirdweb fail.
+	// Ethereum mainnet, sepolia, linea, linea sepolia
+	const METAMASK_LOCKED_CHAIN_IDS = [1, 11155111, 59144, 59141];
+
 	export let wallet: Wallet<WCSupportedWalletIds>;
 	export let walletInfo: WalletInfo;
 	export let chain: Chain | undefined;
@@ -30,9 +34,18 @@
 	const connect = async () => {
 		errorConnecting = false;
 
+		const lockedChain = chains?.find((c) => METAMASK_LOCKED_CHAIN_IDS.includes(c.id));
+		// locked chain needs to be included in the `chain` field, to make sure the connection got approved, and making thirdweb don't call wallet_addEthereumChain
+		const mainChain = lockedChain || chain || chains?.[0];
+
+		const isPreferredChainIncludedInChains = chains?.some((c) => c.id === chain?.id);
+		if (chain && mainChain?.id !== chain?.id && !isPreferredChainIncludedInChains) {
+			chains = [...(chains || []), chain];
+		}
+
 		try {
 			await wallet.connect({
-				chain: chain || chains?.[0],
+				chain: mainChain,
 				client: context.client,
 				walletConnect: {
 					projectId: walletConnect?.projectId,

--- a/src/lib/components/connect-wallet-modal/steps/wallet-connect/walletconnect-standalone-connect.svelte
+++ b/src/lib/components/connect-wallet-modal/steps/wallet-connect/walletconnect-standalone-connect.svelte
@@ -43,7 +43,7 @@
 
 			try {
 				await wallet.connect({
-					chain,
+					chain: chain || chains?.[0],
 					client: context.client,
 					projectId: walletConnect?.projectId,
 					showQrModal: true,
@@ -62,7 +62,7 @@
 		} else {
 			try {
 				await wallet.connect({
-					chain,
+					chain: chain || chains?.[0],
 					client: context.client,
 					projectId: walletConnect?.projectId,
 					showQrModal: false,


### PR DESCRIPTION
Resolves https://github.com/Ozean-L2/website/issues/535

## Issue:
The `chain` param passed to `thirdweb` is the important one to include the chain approval from metamask
Adding the locked chains inside optionalChains won't make the approval to the chains added.

Without this approval, thirdweb will call `wallet_addEthereumChain` first before `wallet_switchEthereumChain`.
This call will fail if we try to add chain for the locked chains (sepolia, mainnet, linea).

## Solution:
Prioritize the approval for locked chains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced wallet connection logic to allow for fallback to the first available chain if a specific chain is not provided.
- **Bug Fixes**
	- Improved error handling in wallet connection processes to manage modal states consistently.
- **Chores**
	- Updated package version from 0.0.3 to 0.0.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->