### PR TITLE
fix: use thirdweb-svelte in svelte v5 environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holdex/thirdweb-svelte",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",
@@ -73,7 +73,7 @@
 		"lucide-svelte": "^0.464.0",
 		"mipd": "^0.0.7",
 		"mode-watcher": "^0.5.0",
-		"svelte-legos": "^0.2.5",
+		"svelte-media-queries": "^1.6.2",
 		"tailwind-merge": "^2.5.5",
 		"tailwind-variants": "^0.3.0",
 		"thirdweb": "^5.73.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,9 @@ importers:
       mode-watcher:
         specifier: ^0.5.0
         version: 0.5.0(svelte@4.2.19)
-      svelte-legos:
-        specifier: ^0.2.5
-        version: 0.2.5(svelte@4.2.19)
+      svelte-media-queries:
+        specifier: ^1.6.2
+        version: 1.6.2
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.5.5
@@ -1456,9 +1456,6 @@ packages:
   caniuse-lite@1.0.30001686:
     resolution: {integrity: sha512-Y7deg0Aergpa24M3qLC5xjNklnKnhsmSyR/V89dLZ1n0ucJIFNs7PgR2Yfa/Zf6W79SbBicgtGxZr2juHkEUIA==}
 
-  canvas-confetti@1.9.3:
-    resolution: {integrity: sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==}
-
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2549,13 +2546,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  prism-svelte@0.5.0:
-    resolution: {integrity: sha512-db91Bf3pRGKDPz1lAqLFSJXeW13mulUJxhycysFpfXV5MIK7RgWWK2E5aPAa71s8TCzQUXxF5JOV42/iOs6QkA==}
-
-  prismjs@1.29.0:
-    resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
-    engines: {node: '>=6'}
-
   process-warning@1.0.0:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
 
@@ -2816,10 +2806,8 @@ packages:
     peerDependencies:
       svelte: ^3.19.0 || ^4.0.0
 
-  svelte-legos@0.2.5:
-    resolution: {integrity: sha512-r4HbLYripCLECgraqJMvsykW/8FaPBd1hLkt3ejJzJRfhhOnCgGTo6lJT27qrestDFbiIASQV3xOnjRr/D6cGw==}
-    peerDependencies:
-      svelte: ^4.0.0
+  svelte-media-queries@1.6.2:
+    resolution: {integrity: sha512-SMz6od/vIeZEGlc4P0HKJK4G0fZotuwFhCSpBQaPqh75h6sL6sNf+4+IjbegFKXbP7b+SOfyzVOIMXTr8jynkA==}
 
   svelte-sonner@0.3.28:
     resolution: {integrity: sha512-K3AmlySeFifF/cKgsYNv5uXqMVNln0NBAacOYgmkQStLa/UoU0LhfAACU6Gr+YYC8bOCHdVmFNoKuDbMEsppJg==}
@@ -4740,8 +4728,6 @@ snapshots:
 
   caniuse-lite@1.0.30001686: {}
 
-  canvas-confetti@1.9.3: {}
-
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -5780,10 +5766,6 @@ snapshots:
 
   prettier@3.4.1: {}
 
-  prism-svelte@0.5.0: {}
-
-  prismjs@1.29.0: {}
-
   process-warning@1.0.0: {}
 
   proxy-compare@2.5.1: {}
@@ -6034,12 +6016,7 @@ snapshots:
     dependencies:
       svelte: 4.2.19
 
-  svelte-legos@0.2.5(svelte@4.2.19):
-    dependencies:
-      canvas-confetti: 1.9.3
-      prism-svelte: 0.5.0
-      prismjs: 1.29.0
-      svelte: 4.2.19
+  svelte-media-queries@1.6.2: {}
 
   svelte-sonner@0.3.28(svelte@4.2.19):
     dependencies:

--- a/src/lib/components/connect-wallet-modal/connect-wallet-modal.svelte
+++ b/src/lib/components/connect-wallet-modal/connect-wallet-modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { mediaQuery } from 'svelte-legos';
+	import MediaQuery from 'svelte-media-queries';
 	import * as Dialog from '$/components/ui/dialog/index.js';
 	import * as Drawer from '$/components/ui/drawer/index.js';
 	import ChevronLeft from 'lucide-svelte/icons/chevron-left';
@@ -18,8 +18,6 @@
 	export let walletConnect: $$Props['walletConnect'] = undefined;
 	export let chains: $$Props['chains'] = undefined;
 	export let wallets: NonNullable<$$Props['wallets']> = getDefaultWallets();
-
-	const isDesktop = mediaQuery('(min-width: 768px)');
 
 	let step: ConnectWalletModalStep = 'provider-selector';
 	let additionalProps: any = undefined;
@@ -55,80 +53,82 @@
 </script>
 
 <AutoConnect {chain} {chains} {wallets} />
-{#if $isDesktop}
-	<Dialog.Root {...$$restProps} bind:open>
-		<Dialog.Content {theme} class={cn('twsv-pb-4')}>
-			<Dialog.Header
-				class={cn(
-					'twsv-relative twsv-flex-row twsv-space-y-0',
-					showBackButton && 'twsv-justify-center'
-				)}
-			>
-				{#if showBackButton}
-					<Button
-						variant="ghost"
-						size="auto"
-						class="twsv-absolute -twsv-left-2 twsv-top-0 twsv-text-muted-foreground"
-						on:click={() => {
-							if (customBackClick) customBackClick();
-							else setStep('provider-selector');
-						}}
-					>
-						<ChevronLeft />
-					</Button>
-				{/if}
-				<Dialog.Title class="twsv-w-fit twsv-text-xl">{title}</Dialog.Title>
-			</Dialog.Header>
-			<ConnectWalletModalContent
-				{wallets}
-				{walletConnect}
-				{additionalProps}
-				{closeModal}
-				{chain}
-				{setStep}
-				{step}
-				{chains}
-				{setCustomBackClick}
-				setModalOpen={(newOpen) => (open = newOpen)}
-			/>
-		</Dialog.Content>
-	</Dialog.Root>
-{:else}
-	<Drawer.Root bind:open>
-		<Drawer.Content>
-			<Drawer.Header
-				class={cn(
-					'twsv-relative twsv-flex-row twsv-space-y-0',
-					showBackButton && 'twsv-justify-center'
-				)}
-			>
-				{#if showBackButton}
-					<Button
-						variant="ghost"
-						size="auto"
-						class="twsv-absolute -twsv-left-2 twsv-top-6 twsv-text-muted-foreground"
-						on:click={() => {
-							if (customBackClick) customBackClick();
-							else setStep('provider-selector');
-						}}
-					>
-						<ChevronLeft />
-					</Button>
-				{/if}
-				<Drawer.Title class="twsv-w-fit twsv-text-xl">{title}</Drawer.Title>
-			</Drawer.Header>
-			<ConnectWalletModalContent
-				{wallets}
-				{walletConnect}
-				{additionalProps}
-				{closeModal}
-				{chain}
-				{setStep}
-				{step}
-				{chains}
-				{setCustomBackClick}
-				setModalOpen={(newOpen) => (open = newOpen)}
-			/>
-		</Drawer.Content>
-	</Drawer.Root>
-{/if}
+<MediaQuery query="(min-width: 768px)" let:matches>
+	{#if matches}
+		<Dialog.Root {...$$restProps} bind:open>
+			<Dialog.Content {theme} class={cn('twsv-pb-4')}>
+				<Dialog.Header
+					class={cn(
+						'twsv-relative twsv-flex-row twsv-space-y-0',
+						showBackButton && 'twsv-justify-center'
+					)}
+				>
+					{#if showBackButton}
+						<Button
+							variant="ghost"
+							size="auto"
+							class="twsv-absolute -twsv-left-2 twsv-top-0 twsv-text-muted-foreground"
+							on:click={() => {
+								if (customBackClick) customBackClick();
+								else setStep('provider-selector');
+							}}
+						>
+							<ChevronLeft />
+						</Button>
+					{/if}
+					<Dialog.Title class="twsv-w-fit twsv-text-xl">{title}</Dialog.Title>
+				</Dialog.Header>
+				<ConnectWalletModalContent
+					{wallets}
+					{walletConnect}
+					{additionalProps}
+					{closeModal}
+					{chain}
+					{setStep}
+					{step}
+					{chains}
+					{setCustomBackClick}
+					setModalOpen={(newOpen) => (open = newOpen)}
+				/>
+			</Dialog.Content>
+		</Dialog.Root>
+	{:else}
+		<Drawer.Root bind:open>
+			<Drawer.Content>
+				<Drawer.Header
+					class={cn(
+						'twsv-relative twsv-flex-row twsv-space-y-0',
+						showBackButton && 'twsv-justify-center'
+					)}
+				>
+					{#if showBackButton}
+						<Button
+							variant="ghost"
+							size="auto"
+							class="twsv-absolute -twsv-left-2 twsv-top-6 twsv-text-muted-foreground"
+							on:click={() => {
+								if (customBackClick) customBackClick();
+								else setStep('provider-selector');
+							}}
+						>
+							<ChevronLeft />
+						</Button>
+					{/if}
+					<Drawer.Title class="twsv-w-fit twsv-text-xl">{title}</Drawer.Title>
+				</Drawer.Header>
+				<ConnectWalletModalContent
+					{wallets}
+					{walletConnect}
+					{additionalProps}
+					{closeModal}
+					{chain}
+					{setStep}
+					{step}
+					{chains}
+					{setCustomBackClick}
+					setModalOpen={(newOpen) => (open = newOpen)}
+				/>
+			</Drawer.Content>
+		</Drawer.Root>
+	{/if}
+</MediaQuery>

--- a/src/lib/components/export-private-key-modal/export-private-key-modal.svelte
+++ b/src/lib/components/export-private-key-modal/export-private-key-modal.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import * as Dialog from '$/components/ui/dialog/index.js';
 	import * as Drawer from '$/components/ui/drawer/index.js';
-	import { mediaQuery } from 'svelte-legos';
+	import MediaQuery from 'svelte-media-queries';
 	import type { ExportPrivateKeyModalProps } from './index.js';
 	import { cn } from '$/utils.js';
 	import ExportPrivateKeyModalContent from './export-private-key-modal-content.svelte';
 	import { getThirdwebSvelteContext } from '../thirdweb-svelte-provider/context.js';
 
-	const isDesktop = mediaQuery('(min-width: 768px)');
 	const { wallet } = getThirdwebSvelteContext();
 
 	type $$Props = ExportPrivateKeyModalProps;
@@ -15,22 +14,24 @@
 	export let theme: $$Props['theme'] = 'dark';
 </script>
 
-{#if $isDesktop}
-	<Dialog.Root {...$$restProps} bind:open>
-		<Dialog.Content {theme} class={cn('twsv-pb-4')}>
-			<Dialog.Header class={cn('twsv-relative twsv-flex-row twsv-space-y-0')}>
-				<Dialog.Title class="twsv-w-fit twsv-text-xl">Export Private Key</Dialog.Title>
-			</Dialog.Header>
-			<ExportPrivateKeyModalContent wallet={$wallet} {theme} />
-		</Dialog.Content>
-	</Dialog.Root>
-{:else}
-	<Drawer.Root bind:open>
-		<Drawer.Content>
-			<Drawer.Header class={cn('twsv-relative twsv-flex-row twsv-space-y-0')}>
-				<Drawer.Title class="twsv-w-fit twsv-text-xl">Export Private Key</Drawer.Title>
-			</Drawer.Header>
-			<ExportPrivateKeyModalContent wallet={$wallet} {theme} />
-		</Drawer.Content>
-	</Drawer.Root>
-{/if}
+<MediaQuery query="(min-width: 768px)" let:matches>
+	{#if matches}
+		<Dialog.Root {...$$restProps} bind:open>
+			<Dialog.Content {theme} class={cn('twsv-pb-4')}>
+				<Dialog.Header class={cn('twsv-relative twsv-flex-row twsv-space-y-0')}>
+					<Dialog.Title class="twsv-w-fit twsv-text-xl">Export Private Key</Dialog.Title>
+				</Dialog.Header>
+				<ExportPrivateKeyModalContent wallet={$wallet} {theme} />
+			</Dialog.Content>
+		</Dialog.Root>
+	{:else}
+		<Drawer.Root bind:open>
+			<Drawer.Content>
+				<Drawer.Header class={cn('twsv-relative twsv-flex-row twsv-space-y-0')}>
+					<Drawer.Title class="twsv-w-fit twsv-text-xl">Export Private Key</Drawer.Title>
+				</Drawer.Header>
+				<ExportPrivateKeyModalContent wallet={$wallet} {theme} />
+			</Drawer.Content>
+		</Drawer.Root>
+	{/if}
+</MediaQuery>


### PR DESCRIPTION
resolves https://github.com/holdex/marketing/issues/100

Tested with new svelte@v5 repo in my local.
Please follow [Development Guidelines](https://github.com/holdex/thirdweb-svelte?tab=readme-ov-file#development-guidelines) to check it locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated package version from 0.0.9 to 0.0.10
	- Replaced `svelte-legos` library with `svelte-media-queries`

- **Improvements**
	- Enhanced media query handling in connect wallet and export private key modals
	- Switched to more responsive component-based media query approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->