### PR TITLE
chore: change peer dep to include v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holdex/thirdweb-svelte",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",
@@ -36,7 +36,7 @@
 		"access": "public"
 	},
 	"peerDependencies": {
-		"svelte": "^4.0.0",
+		"svelte": "^4.0.0 || ^5.0.0",
 		"thirdweb": "^5.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
resolves https://github.com/holdex/marketing/issues/103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package version to 0.0.11
	- Extended Svelte peer dependency to support version 5 alongside version 4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->