### PR TITLE
feat: use Inter font for modals and allow user to pass custom classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holdex/thirdweb-svelte",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holdex/thirdweb-svelte",
-	"version": "0.0.12",
+	"version": "0.1.12",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",

--- a/src/app.html
+++ b/src/app.html
@@ -104,7 +104,7 @@
 
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover">
-		<div class="twsv-font-sans">%sveltekit.body%</div>
+	<body data-sveltekit-preload-data="hover" class="twsv-font-sans">
+		<div>%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/lib/components/connect-wallet-modal/connect-wallet-modal.svelte
+++ b/src/lib/components/connect-wallet-modal/connect-wallet-modal.svelte
@@ -18,6 +18,7 @@
 	export let walletConnect: $$Props['walletConnect'] = undefined;
 	export let chains: $$Props['chains'] = undefined;
 	export let wallets: NonNullable<$$Props['wallets']> = getDefaultWallets();
+	export let contentClassName: $$Props['contentClassName'] = '';
 
 	let step: ConnectWalletModalStep = 'provider-selector';
 	let additionalProps: any = undefined;
@@ -56,7 +57,7 @@
 <MediaQuery query="(min-width: 768px)" let:matches>
 	{#if matches}
 		<Dialog.Root {...$$restProps} bind:open>
-			<Dialog.Content {theme} class={cn('twsv-pb-4 twsv-font-sans')}>
+			<Dialog.Content {theme} class={cn('twsv-pb-4 twsv-font-sans', contentClassName)}>
 				<Dialog.Header
 					class={cn(
 						'twsv-relative twsv-flex-row twsv-space-y-0',
@@ -94,7 +95,7 @@
 		</Dialog.Root>
 	{:else}
 		<Drawer.Root bind:open>
-			<Drawer.Content>
+			<Drawer.Content class={cn('twsv-font-sans', contentClassName)}>
 				<Drawer.Header
 					class={cn(
 						'twsv-relative twsv-flex-row twsv-space-y-0',

--- a/src/lib/components/connect-wallet-modal/connect-wallet-modal.svelte
+++ b/src/lib/components/connect-wallet-modal/connect-wallet-modal.svelte
@@ -56,7 +56,7 @@
 <MediaQuery query="(min-width: 768px)" let:matches>
 	{#if matches}
 		<Dialog.Root {...$$restProps} bind:open>
-			<Dialog.Content {theme} class={cn('twsv-pb-4')}>
+			<Dialog.Content {theme} class={cn('twsv-pb-4 twsv-font-sans')}>
 				<Dialog.Header
 					class={cn(
 						'twsv-relative twsv-flex-row twsv-space-y-0',

--- a/src/lib/components/connect-wallet-modal/index.ts
+++ b/src/lib/components/connect-wallet-modal/index.ts
@@ -5,6 +5,15 @@ import type { Wallet } from 'thirdweb/wallets';
 
 type ConnectWalletModalProps = DialogProps & {
 	/**
+	 * Set the class name for the content of the `ConnectWalletModal` component.
+	 * You can change the font, padding, etc.
+	 *
+	 * e.g. if you use tailwind, and want to change the font to use your website's font, you can pass `contentClassName="font-inherit"`.
+	 * In that case, the font that will be used is the font you set to the `body` tag in the `app.html` file.
+	 */
+	contentClassName?: string;
+
+	/**
 	 * Array of supported wallets. If not provided, default wallets will be used.
 	 * @example
 	 * ```tsx

--- a/src/lib/components/export-private-key-modal/export-private-key-modal.svelte
+++ b/src/lib/components/export-private-key-modal/export-private-key-modal.svelte
@@ -10,6 +10,7 @@
 	const { wallet } = getThirdwebSvelteContext();
 
 	type $$Props = ExportPrivateKeyModalProps;
+	export let contentClassName: $$Props['contentClassName'] = '';
 	export let open: $$Props['open'] = false;
 	export let theme: $$Props['theme'] = 'dark';
 </script>
@@ -17,7 +18,7 @@
 <MediaQuery query="(min-width: 768px)" let:matches>
 	{#if matches}
 		<Dialog.Root {...$$restProps} bind:open>
-			<Dialog.Content {theme} class={cn('twsv-pb-4 twsv-font-sans')}>
+			<Dialog.Content {theme} class={cn('twsv-pb-4 twsv-font-sans', contentClassName)}>
 				<Dialog.Header class={cn('twsv-relative twsv-flex-row twsv-space-y-0')}>
 					<Dialog.Title class="twsv-w-fit twsv-text-xl">Export Private Key</Dialog.Title>
 				</Dialog.Header>
@@ -26,7 +27,7 @@
 		</Dialog.Root>
 	{:else}
 		<Drawer.Root bind:open>
-			<Drawer.Content class="twsv-font-sans">
+			<Drawer.Content class={cn('twsv-font-sans', contentClassName)}>
 				<Drawer.Header class={cn('twsv-relative twsv-flex-row twsv-space-y-0')}>
 					<Drawer.Title class="twsv-w-fit twsv-text-xl">Export Private Key</Drawer.Title>
 				</Drawer.Header>

--- a/src/lib/components/export-private-key-modal/export-private-key-modal.svelte
+++ b/src/lib/components/export-private-key-modal/export-private-key-modal.svelte
@@ -17,7 +17,7 @@
 <MediaQuery query="(min-width: 768px)" let:matches>
 	{#if matches}
 		<Dialog.Root {...$$restProps} bind:open>
-			<Dialog.Content {theme} class={cn('twsv-pb-4')}>
+			<Dialog.Content {theme} class={cn('twsv-pb-4 twsv-font-sans')}>
 				<Dialog.Header class={cn('twsv-relative twsv-flex-row twsv-space-y-0')}>
 					<Dialog.Title class="twsv-w-fit twsv-text-xl">Export Private Key</Dialog.Title>
 				</Dialog.Header>
@@ -26,7 +26,7 @@
 		</Dialog.Root>
 	{:else}
 		<Drawer.Root bind:open>
-			<Drawer.Content>
+			<Drawer.Content class="twsv-font-sans">
 				<Drawer.Header class={cn('twsv-relative twsv-flex-row twsv-space-y-0')}>
 					<Drawer.Title class="twsv-w-fit twsv-text-xl">Export Private Key</Drawer.Title>
 				</Drawer.Header>

--- a/src/lib/components/export-private-key-modal/index.ts
+++ b/src/lib/components/export-private-key-modal/index.ts
@@ -8,6 +8,15 @@ type ExportPrivateKeyModalProps = DialogProps & {
 	 * theme can be set to either `"dark"`, `"light"`.
 	 */
 	theme?: 'light' | 'dark';
+
+	/**
+	 * Set the class name for the content of the `ConnectWalletModal` component.
+	 * You can change the font, padding, etc.
+	 *
+	 * e.g. if you use tailwind, and want to change the font to use your website's font, you can pass `contentClassName="font-inherit"`.
+	 * In that case, the font that will be used is the font you set to the `body` tag in the `app.html` file.
+	 */
+	contentClassName?: string;
 };
 
 export { type ExportPrivateKeyModalProps, ExportPrivateKeyModal };


### PR DESCRIPTION
resolves #38 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Introduced a new property to customize modal styling with `contentClassName`, allowing for additional CSS class names to be applied.
  - Updated the `ConnectWalletModal` and `ExportPrivateKeyModal` components to incorporate the new property for enhanced styling flexibility.

- **Chores**
  - Updated the package version of `@holdex/thirdweb-svelte` from `0.0.11` to `0.0.12`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->