### PR TITLE
feat: allow consumer app to set their own query provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Install both the Svelte SDK and the core thirdweb library:
 
 ```bash
-pnpm i @holdex/thirdweb-svelte thirdweb @tanstack/svelte-query
+pnpm i @holdex/thirdweb-svelte thirdweb @tanstack/svelte-query vaul-svelte
 ```
 
 ### 2. Setup Provider

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Add the ThirdwebSvelteProvider to your `src/routes/+layout.svelte`:
 <script>
 	import { ThirdwebSvelteProvider } from '@holdex/thirdweb-svelte';
 	import { browser } from '$app/environment';
+	import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
 
 	const queryClient = new QueryClient({
 		defaultOptions: {

--- a/README.md
+++ b/README.md
@@ -8,21 +8,32 @@
 Install both the Svelte SDK and the core thirdweb library:
 
 ```bash
-pnpm i @holdex/thirdweb-svelte thirdweb
+pnpm i @holdex/thirdweb-svelte thirdweb @tanstack/svelte-query
 ```
 
 ### 2. Setup Provider
 
-Add the ThirdwebSvelteProvider to your `src/routes/layout.svelte`:
+Add the ThirdwebSvelteProvider to your `src/routes/+layout.svelte`:
 
 ```svelte
 <script>
 	import { ThirdwebSvelteProvider } from '@holdex/thirdweb-svelte';
+	import { browser } from '$app/environment';
+
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {
+				enabled: browser
+			}
+		}
+	});
 </script>
 
-<ThirdwebSvelteProvider clientId={YOUR_THIRDWEB_CLIENT_ID}>
-	<slot />
-</ThirdwebSvelteProvider>
+<QueryClientProvider client={queryClient}>
+	<ThirdwebSvelteProvider clientId={YOUR_THIRDWEB_CLIENT_ID}>
+		<slot />
+	</ThirdwebSvelteProvider>
+</QueryClientProvider>
 ```
 
 ### 3. Implement Wallet Connection
@@ -71,6 +82,23 @@ Note that this modal is only available for inApp wallets. If you would like to c
 {#if wallet.type === 'inApp'}
 	<!-- Show Export Private Key button -->
 {/if}
+```
+
+## Known Issues
+
+1. In Svelte 5, the `isInitialized` state from `getThirdwebSvelteContext()` may show inconsistent values across different parts of your component. To work around this, create a local state variable that tracks the initialization status:
+
+```svelte
+<script lang="ts">
+	import { getThirdwebSvelteContext } from '@holdex/thirdweb-svelte';
+
+	const { isInitialized } = getThirdwebSvelteContext();
+	let isInit = $state(false);
+
+	$effect(() => {
+		isInit = $isInitialized;
+	});
+</script>
 ```
 
 ## Development Guidelines

--- a/README.md
+++ b/README.md
@@ -87,19 +87,55 @@ Note that this modal is only available for inApp wallets. If you would like to c
 
 ## Known Issues
 
-1. In Svelte 5, the `isInitialized` state from `getThirdwebSvelteContext()` may show inconsistent values across different parts of your component. To work around this, create a local state variable that tracks the initialization status:
+1. **Svelte 5 Initialization State Inconsistency**
+
+The `isInitialized` state from `getThirdwebSvelteContext()` may show inconsistent values in Svelte 5 components. To fix this, create a local state that syncs with the initialization status:
 
 ```svelte
 <script lang="ts">
 	import { getThirdwebSvelteContext } from '@holdex/thirdweb-svelte';
 
+	// Create local state to track initialization
 	const { isInitialized } = getThirdwebSvelteContext();
-	let isInit = $state(false);
+	let isWalletInitialized = $state(false);
 
+	// Keep local state in sync
 	$effect(() => {
-		isInit = $isInitialized;
+		isWalletInitialized = $isInitialized;
 	});
 </script>
+```
+
+2. **Vaul-svelte Version Compatibility**
+
+You must use vaul-svelte@0.3.2 even with Svelte 5 (not vaul-svelte@next). While this version has a drawer entry animation issue in Svelte 5, you can fix it with custom animation:
+
+If you're using the shadcn-svelte drawer component with bottom slide animation:
+
+1. Add these animation styles to your `tailwind.config.ts`:
+
+```ts
+{
+  extend: {
+    keyframes: {
+      'slide-from-bottom': {
+        from: { transform: 'translate3d(0, 100%, 0)' },
+        to: { transform: 'translate3d(0, 0, 0)' }
+      }
+    },
+    animation: {
+      'slide-from-bottom': 'slide-from-bottom 0.5s cubic-bezier(0.32, 0.72, 0, 1)'
+    }
+  }
+}
+```
+
+2. Apply the animation class to your drawer content:
+
+```svelte
+<DrawerPrimitive.Content class="animate-slide-from-bottom ...">
+	<!-- Your drawer content -->
+</DrawerPrimitive.Content>
 ```
 
 ## Development Guidelines
@@ -108,13 +144,17 @@ Note that this modal is only available for inApp wallets. If you would like to c
 
 1. Clone the repository
 2. Install dependencies:
-   ```bash
-   pnpm install
-   ```
+
+```bash
+pnpm install
+```
+
 3. Start the development server:
-   ```bash
-   pnpm dev
-   ```
+
+```bash
+pnpm dev
+```
+
 4. Visit `http://localhost:5173` to see the test page with working wallet connection functionality
 
 ### Repository Structure
@@ -126,13 +166,16 @@ Note that this modal is only available for inApp wallets. If you would like to c
 ### Building
 
 - To build the package for npm:
-  ```bash
-  pnpm package
-  ```
+
+```bash
+pnpm package
+```
+
 - To build the complete application:
-  ```bash
-  pnpm build
-  ```
+
+```bash
+pnpm build
+```
 
 ### Testing
 
@@ -143,21 +186,26 @@ You can test the library using the app code in `src/routes`. This directory cont
 To test your local library changes in another project:
 
 1. Build the package:
-   ```bash
-   pnpm package
-   ```
+
+```bash
+pnpm package
+```
+
 2. In your consumer project, update the dependency in `package.json`:
-   ```json
-   {
-   	"dependencies": {
-   		"@holdex/thirdweb-svelte": "file:../path/to/your/local/thirdweb-svelte"
-   	}
-   }
-   ```
+
+```json
+{
+	"dependencies": {
+		"@holdex/thirdweb-svelte": "file:../path/to/your/local/thirdweb-svelte"
+	}
+}
+```
+
 3. Reinstall dependencies in your consumer project:
-   ```bash
-   pnpm install
-   ```
+
+```bash
+pnpm install
+```
 
 ### Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"elliptic": "^6.6.1"
 	},
 	"peerDependencies": {
+		"@tanstack/svelte-query": "^5.66.0",
 		"svelte": "^4.0.0 || ^5.0.0",
 		"thirdweb": "^5.0.0"
 	},
@@ -75,7 +76,6 @@
 	},
 	"dependencies": {
 		"@jimmyverburgt/svelte-input-otp": "^0.0.3",
-		"@tanstack/svelte-query": "^5.66.0",
 		"bits-ui": "^0.22.0",
 		"clsx": "^2.1.1",
 		"lucide-svelte": "^0.464.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holdex/thirdweb-svelte",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && pnpm run package",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
 	"peerDependencies": {
 		"@tanstack/svelte-query": "^5.66.0",
 		"svelte": "^4.0.0 || ^5.0.0",
-		"thirdweb": "^5.0.0"
+		"thirdweb": "^5.0.0",
+		"vaul-svelte": "^0.3.2"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.2.6",
@@ -54,6 +55,7 @@
 		"@sveltejs/kit": "^2.17.2",
 		"@sveltejs/package": "^2.3.10",
 		"@sveltejs/vite-plugin-svelte": "^3.1.2",
+		"@tanstack/svelte-query": "^5.66.0",
 		"@types/node": "^22.13.4",
 		"abitype": "^1.0.8",
 		"autoprefixer": "^10.4.20",
@@ -70,8 +72,10 @@
 		"svelte-check": "^4.1.4",
 		"tailwind-scrollbar": "^3.1.0",
 		"tailwindcss": "^3.4.17",
+		"thirdweb": "^5.88.4",
 		"typescript": "^5.7.3",
 		"typescript-eslint": "^8.24.0",
+		"vaul-svelte": "^0.3.2",
 		"vite": "^5.4.14"
 	},
 	"dependencies": {
@@ -85,8 +89,6 @@
 		"svelte-sonner": "^0.3.28",
 		"tailwind-merge": "^2.6.0",
 		"tailwind-variants": "^0.3.1",
-		"thirdweb": "^5.88.4",
-		"uqr": "^0.1.2",
-		"vaul-svelte": "^0.3.2"
+		"uqr": "^0.1.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@jimmyverburgt/svelte-input-otp':
         specifier: ^0.0.3
         version: 0.0.3(svelte@4.2.19)
-      '@tanstack/svelte-query':
-        specifier: ^5.66.0
-        version: 5.66.0(svelte@4.2.19)
       bits-ui:
         specifier: ^0.22.0
         version: 0.22.0(svelte@4.2.19)
@@ -44,15 +41,9 @@ importers:
       tailwind-variants:
         specifier: ^0.3.1
         version: 0.3.1(tailwindcss@3.4.17)
-      thirdweb:
-        specifier: ^5.88.4
-        version: 5.88.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       uqr:
         specifier: ^0.1.2
         version: 0.1.2
-      vaul-svelte:
-        specifier: ^0.3.2
-        version: 0.3.2(svelte@4.2.19)
     devDependencies:
       '@eslint/compat':
         specifier: ^1.2.6
@@ -69,6 +60,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.2
         version: 3.1.2(svelte@4.2.19)(vite@5.4.14(@types/node@22.13.4))
+      '@tanstack/svelte-query':
+        specifier: ^5.66.0
+        version: 5.66.0(svelte@4.2.19)
       '@types/node':
         specifier: ^22.13.4
         version: 22.13.4
@@ -117,12 +111,18 @@ importers:
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17
+      thirdweb:
+        specifier: ^5.88.4
+        version: 5.88.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
       typescript-eslint:
         specifier: ^8.24.0
         version: 8.24.0(eslint@9.20.1(jiti@2.4.1))(typescript@5.7.3)
+      vaul-svelte:
+        specifier: ^0.3.2
+        version: 0.3.2(svelte@4.2.19)
       vite:
         specifier: ^5.4.14
         version: 5.4.14(@types/node@22.13.4)

--- a/src/lib/components/thirdweb-svelte-provider/thirdweb-svelte-provider.svelte
+++ b/src/lib/components/thirdweb-svelte-provider/thirdweb-svelte-provider.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
 	import { type Wallet } from 'thirdweb/wallets';
 	import { setThirdwebSvelteContext, type AccountWithChain } from './context.js';
 	import { createThirdwebClient } from 'thirdweb';
@@ -47,8 +46,6 @@
 		isInitialized
 	});
 
-	const queryClient = new QueryClient();
-
 	let unsub: (() => void) | undefined;
 	$: {
 		const unsubAccountChanged = $wallet?.subscribe('accountChanged', () => {
@@ -73,6 +70,4 @@
 	});
 </script>
 
-<QueryClientProvider client={queryClient}>
-	<slot />
-</QueryClientProvider>
+<slot />

--- a/src/lib/components/ui/drawer/drawer-content.svelte
+++ b/src/lib/components/ui/drawer/drawer-content.svelte
@@ -17,7 +17,7 @@
 	<DrawerOverlay class={cn(theme === 'dark' && 'dark')} />
 	<DrawerPrimitive.Content
 		class={cn(
-			'twsv-fixed twsv-inset-x-0 twsv-bottom-0 twsv-z-50 twsv-mt-24 twsv-flex twsv-h-auto twsv-flex-col twsv-rounded-t-[10px] twsv-border twsv-border-border twsv-bg-background twsv-px-6 twsv-pb-4 twsv-text-foreground',
+			'twsv-animate-slide-from-bottom twsv-fixed twsv-inset-x-0 twsv-bottom-0 twsv-z-50 twsv-mt-24 twsv-flex twsv-h-auto twsv-flex-col twsv-rounded-t-[10px] twsv-border twsv-border-border twsv-bg-background twsv-px-6 twsv-pb-4 twsv-text-foreground',
 			theme === 'dark' && 'dark',
 			className
 		)}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,16 @@
 	import ThirdwebSvelteProvider from '$/components/thirdweb-svelte-provider/thirdweb-svelte-provider.svelte';
 	import { PUBLIC_THIRDWEB_CLIENT_ID } from '$env/static/public';
 	import '../app.css';
+	import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
+	import { browser } from '$app/environment';
+
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {
+				enabled: browser
+			}
+		}
+	});
 
 	$: {
 		async function initEruda() {
@@ -20,6 +30,8 @@
 
 <ModeWatcher defaultMode="dark" />
 <Toaster />
-<ThirdwebSvelteProvider clientId={PUBLIC_THIRDWEB_CLIENT_ID}>
-	<slot />
-</ThirdwebSvelteProvider>
+<QueryClientProvider client={queryClient}>
+	<ThirdwebSvelteProvider clientId={PUBLIC_THIRDWEB_CLIENT_ID}>
+		<slot />
+	</ThirdwebSvelteProvider>
+</QueryClientProvider>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 	import { toast } from 'svelte-sonner';
 	import ConnectWalletButton from '$/components/connect-wallet-button/connect-wallet-button.svelte';
 
-	const command = 'pnpm i @holdex/thirdweb-svelte thirdweb';
+	const command = 'pnpm i @holdex/thirdweb-svelte thirdweb @tanstack/svelte-query vaul-svelte';
 </script>
 
 <main class="twsv-flex twsv-min-h-screen twsv-w-full twsv-flex-col twsv-items-center">

--- a/src/routes/try-me/+page.svelte
+++ b/src/routes/try-me/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import ConnectWalletButton from '$/components/connect-wallet-button/connect-wallet-button.svelte';
-</script>
-
-<div class="twsv-flex twsv-h-screen twsv-w-screen twsv-items-center twsv-justify-center">
-	<ConnectWalletButton />
-</div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -35,11 +35,16 @@ const config: Config = {
 					'100%': {
 						transform: 'rotate(360deg)'
 					}
+				},
+				'slide-from-bottom': {
+					from: { transform: 'translate3d(0, 100%, 0)' },
+					to: { transform: 'translate3d(0, 0, 0)' }
 				}
 			},
 			animation: {
 				'dash-animation': 'dash-animation 1.5s ease-in-out infinite',
-				'rotate-animation': 'rotate-animation 2s linear infinite'
+				'rotate-animation': 'rotate-animation 2s linear infinite',
+				'slide-from-bottom': 'slide-from-bottom 0.5s cubic-bezier(0.32, 0.72, 0, 1)'
 			},
 			colors: {
 				border: 'hsl(var(--twsv-border) / <alpha-value>)',


### PR DESCRIPTION
resolves #46 

@tanstack/svelte-query reason to be peer dep:
- If user needs to use custom queryClient behavior, this can be done easily if the provider mounting is deferred to consumer app instead

vaul-svelte reason to be peer dep:
- If the consumer is using svelte v5, its recommended to use vaul@next, but because here its using vaul@0.3.2, the styles are colliding with each other creating bug.
- Solution: recommend consumer app to use vaul@0.3.2 instead. It works fine in svelte v5, with one issue, where entry animation don't work, but its fixed with custom animation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Installation instructions and setup guides have been updated, and a new "Known Issues" section has been added for clarity.
- **New Features**
  - The UI now features enhanced drawer animations that create a smoother slide effect.
  - The application layout has been improved to provide a more robust approach to data handling.
- **Chores**
  - Package version has been bumped, and dependency management has been refreshed.
  - Redundant components have been removed to streamline functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->