### PR TITLE
docs: view emfile error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,22 @@ Note that this modal is only available for inApp wallets. If you would like to c
 
 ## Known Issues
 
-1. **Svelte 5 Initialization State Inconsistency**
+1. **Vercel Deployment EMFILE Error**
+
+For production deployments (especially on Vercel), you may encounter an EMFILE error (too many files open) due to thirdweb and viem packages. To resolve this, add the following configuration to your `vite.config.ts`:
+
+```ts
+export default defineConfig({
+	// ...existing config
+	ssr: {
+		noExternal: ['thirdweb', 'viem']
+	}
+});
+```
+
+This configuration prevents thirdweb and viem from running during SSR, which resolves the file descriptor limit issue during build processes.
+
+2. **Svelte 5 Initialization State Inconsistency**
 
 The `isInitialized` state from `getThirdwebSvelteContext()` may show inconsistent values in Svelte 5 components. To fix this, create a local state that syncs with the initialization status:
 
@@ -113,7 +128,7 @@ The `isInitialized` state from `getThirdwebSvelteContext()` may show inconsisten
 </script>
 ```
 
-2. **Vaul-svelte Version Compatibility** (only for v0.x)
+3. **Vaul-svelte Version Compatibility** (only for v0.x)
 
 You must use vaul-svelte@0.3.2 even with Svelte 5 (not vaul-svelte@next). While this version has a drawer entry animation issue in Svelte 5, you can fix it with custom animation:
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ export default defineConfig({
 });
 ```
 
-This configuration prevents thirdweb and viem from running during SSR, which resolves the file descriptor limit issue during build processes.
+This configuration tells Vite not to externalize `thirdweb` and `viem` during SSR builds—bundling them instead—which helps avoid EMFILE by reducing filesystem load during dependency resolution in production (e.g., on Vercel).
 
 2. **Svelte 5 Initialization State Inconsistency**
 


### PR DESCRIPTION
resolves https://github.com/holdex/thirdweb-svelte/issues/63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Known Issues entry for Vercel deployment EMFILE error with SSR build guidance to avoid file-descriptor limits.
  * Clarified Svelte 5 initialization inconsistency and added a practical sync workaround example.
  * Renumbered Known Issues; Vaul-svelte compatibility moved to item 3.
  * Expanded Vaul-svelte 0.x guidance with two-step instructions to enable a bottom-slide drawer animation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->